### PR TITLE
chore(docker): Use different project names for dev and production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,11 @@ SERVICE:=epigraphhub
 # options: dev, prod
 ENV:=dev
 
-DOCKER_BASE=docker-compose \
+DOCKER=docker-compose \
 	--env-file .env \
+	--project-name eph-$(ENV) \
 	--file docker/compose-base.yaml \
-
-ifeq ($(ENV), dev)
-DOCKER=$(DOCKER_BASE) --project-name eph-dev --file docker/compose-dev.yaml
-endif
-
-ifeq ($(ENV), prod)
-DOCKER=$(DOCKER_BASE) --project-name eph-prod --file docker/compose-prod.yaml
-endif
-
+	--file docker/compose-$(ENV).yaml
 
 # DOCKER
 

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,16 @@ SERVICE:=epigraphhub
 # options: dev, prod
 ENV:=dev
 
+DOCKER_BASE=docker-compose \
+	--env-file .env \
+	--file docker/compose-base.yaml \
+
 ifeq ($(ENV), dev)
-DOCKER=docker-compose --env-file .env --file docker/compose-base.yaml --file docker/compose-dev.yaml
+DOCKER=$(DOCKER_BASE) --project-name eph-dev --file docker/compose-dev.yaml
 endif
 
 ifeq ($(ENV), prod)
-DOCKER=docker-compose --env-file .env --file docker/compose-base.yaml --file docker/compose-prod.yaml
+DOCKER=$(DOCKER_BASE) --project-name eph-prod --file docker/compose-prod.yaml
 endif
 
 

--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 
+PROJECT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd ../ && pwd )"
+
+env $(cat ${PROJECT_DIR}/.env)
+
 export CONTAINER_NAME=${1:-"epigraphhub"}
-export CONTAINER_NAME="docker_${CONTAINER_NAME}_1"
+export CONTAINER_NAME="eph-${ENV:-dev}_${CONTAINER_NAME}_1"
 
 echo "[II] Checking ${CONTAINER_NAME} ..."
 
-while [ "`docker inspect -f {{.State.Health.Status}} ${CONTAINER_NAME}`" != "healthy" ]; 
+while [ "`docker inspect -f {{.State.Health.Status}} ${CONTAINER_NAME}`" != "healthy" ];
 do
     echo "[II] Waiting for ${CONTAINER_NAME} ..."
     sleep 5;


### PR DESCRIPTION
This PR aims to define a different docker project name for production and for development