### PR TITLE
Changed the default role for new users.

### DIFF
--- a/docker/superset/superset_config.py
+++ b/docker/superset/superset_config.py
@@ -1,8 +1,7 @@
 import os
 
-from celery.schedules import crontab
 from cachelib.redis import RedisCache
-from cachelib.file import FileSystemCache
+from celery.schedules import crontab
 
 # Superset specific config
 SECRET_KEY = os.getenv("SUPERSET_SECRET_KEY", "\2\1thisismyscretkey\1\2\e\y\y\h")
@@ -126,7 +125,7 @@ MAIL_DEFAULT_SENDER = os.getenv("SUPERSET_MAIL_DEFAULT_SENDER")
 # REGISTRATION
 
 AUTH_USER_REGISTRATION = True
-AUTH_USER_REGISTRATION_ROLE = os.getenv("SUPERSET_DEFAULT_NEW_ROLES", "Public")
+AUTH_USER_REGISTRATION_ROLE = "Data_scientist"
 
 # RECAPTCHA
 RECAPTCHA_USE_SSL = False


### PR DESCRIPTION
I have created a `Data_scientist` role on the production server so that we can use it for new users.

I am not sure that we can use a role that is not one of the default here, so before putting in production we should test this in the staging server so that we can be sure that user registration works as we want. We may need to create a role with this name on staging before try to register a new user.