### PR TITLE
fix(conda): pin python version as the same version of airflow container

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,6 @@ env:
   _AIRFLOW_WWW_USER_LAST_NAME: Admin
   _AIRFLOW_WWW_USER_PASSWORD: airflow
   _AIRFLOW_WWW_USER_USERNAME: airflow
-  AIRFLOW_FILES_PATH_DIR_HOST: /tmp/airflow
   AIRFLOW_FILES_PATH_DIR_HOST: /home/runner/work/EpiGraphHub/EpiGraphHub/docker/airflow
   AIRFLOW_HOME: /opt/airflow
   AIRFLOW_PORT: 8099

--- a/conda/base.yaml
+++ b/conda/base.yaml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
+  - python 3.9.*
   - awscli
   - docker-compose
   - git

--- a/containers/airflow/Dockerfile
+++ b/containers/airflow/Dockerfile
@@ -72,8 +72,7 @@ RUN apt-get update -y \
   && echo "epigraphhub ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/epigraphhub \
   && chmod 0440 /etc/sudoers.d/epigraphhub \
   && mkdir -p /opt/superset \
-  && chown epigraphhub:epigraphhub /opt/superset \
-  && chmod a+rw /var/log/
+  && chown epigraphhub:epigraphhub /opt/superset
 
 USER epigraphhub
 
@@ -105,8 +104,7 @@ COPY --chown=epigraphhub:epigraphhub containers/superset/entrypoint.sh /opt/entr
 RUN chmod +x /opt/entrypoint.sh \
   && echo "source /opt/entrypoint.sh" > ~/.bashrc \
   && sudo mkdir -p /opt/data/superset/ \
-  && sudo chown -R epigraphhub:epigraphhub /opt/data \
-  && sudo chown -R epigraphhub:epigraphhub /var/log/*
+  && sudo chown -R epigraphhub:epigraphhub /opt/data
 
 # note: the steps above were copied from the superset + some apt deps
 #       needed by airflow
@@ -122,11 +120,7 @@ RUN sudo ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
 RUN sudo mkdir -p /opt/scripts /sources /opt/airflow \
   && sudo chown -R epigraphhub:epigraphhub /opt/scripts \
   && sudo chown -R epigraphhub:epigraphhub /sources \
-  && sudo chown -R epigraphhub:epigraphhub /opt/airflow \
-  && sudo touch /var/log/owid_fetch.log \
-  && sudo touch /var/log/foph_fetch.log \
-  && sudo touch /var/log/colombia_fetch.log \
-  && sudo chown -R epigraphhub:epigraphhub /var/log/*
+  && sudo chown -R epigraphhub:epigraphhub /opt/airflow
 
 COPY --chown=epigraphhub ./containers/airflow/airflow.cfg /opt/airflow/airflow.cfg
 COPY --chown=epigraphhub ./containers/airflow/scripts/*.sh /opt/scripts/

--- a/containers/airflow/Dockerfile
+++ b/containers/airflow/Dockerfile
@@ -72,7 +72,8 @@ RUN apt-get update -y \
   && echo "epigraphhub ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/epigraphhub \
   && chmod 0440 /etc/sudoers.d/epigraphhub \
   && mkdir -p /opt/superset \
-  && chown epigraphhub:epigraphhub /opt/superset
+  && chown epigraphhub:epigraphhub /opt/superset \
+  && chmod a+rw /var/log/
 
 USER epigraphhub
 
@@ -104,7 +105,8 @@ COPY --chown=epigraphhub:epigraphhub containers/superset/entrypoint.sh /opt/entr
 RUN chmod +x /opt/entrypoint.sh \
   && echo "source /opt/entrypoint.sh" > ~/.bashrc \
   && sudo mkdir -p /opt/data/superset/ \
-  && sudo chown -R epigraphhub:epigraphhub /opt/data
+  && sudo chown -R epigraphhub:epigraphhub /opt/data \
+  && sudo chown -R epigraphhub:epigraphhub /var/log/*
 
 # note: the steps above were copied from the superset + some apt deps
 #       needed by airflow
@@ -120,7 +122,11 @@ RUN sudo ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
 RUN sudo mkdir -p /opt/scripts /sources /opt/airflow \
   && sudo chown -R epigraphhub:epigraphhub /opt/scripts \
   && sudo chown -R epigraphhub:epigraphhub /sources \
-  && sudo chown -R epigraphhub:epigraphhub /opt/airflow
+  && sudo chown -R epigraphhub:epigraphhub /opt/airflow \
+  && sudo touch /var/log/owid_fetch.log \
+  && sudo touch /var/log/foph_fetch.log \
+  && sudo touch /var/log/colombia_fetch.log \
+  && sudo chown -R epigraphhub:epigraphhub /var/log/*
 
 COPY --chown=epigraphhub ./containers/airflow/airflow.cfg /opt/airflow/airflow.cfg
 COPY --chown=epigraphhub ./containers/airflow/scripts/*.sh /opt/scripts/

--- a/containers/airflow/scripts/startup.sh
+++ b/containers/airflow/scripts/startup.sh
@@ -24,8 +24,5 @@ sleep 10
 mkdir -p /tmp/empty
 cd /tmp/empty
 
-# give privileges to log files
-chown -R $USER:$USER /var/log/*
-
 echo "========= DONE ========="
 python -m http.server


### PR DESCRIPTION
The lib and the airflow's container both require `Python >=3.9,<3.11` version to run. Pinning the version as the same as Airflow uses.