### PR TITLE
fix(packages): py version to 3.9 & add superset secondary dependencies

### DIFF
--- a/conda/superset.yaml
+++ b/conda/superset.yaml
@@ -10,13 +10,23 @@ dependencies:
   - openpyxl
   - pip
   - psycopg2
-  - python
+  - python 3.9.*
   - python-dotenv
   - sqlalchemy
-  - superset 1.5.*
+  - jsonschema<5,>=3
   # dependencies from superset 1.5.*
+  - cryptography<39.0.0
+  - pyOpenSSL 23.0.0
+  - slackclient
   - typing-extensions<4,>=3.10
   - enum34
   - pip
+  - 'numpy>=1.17.3'
   - pip:
     - -r pip.txt
+    - packaging
+    - webencodings
+    - 'msgpack<1.1,>=1.0.0'
+    - markupsafe==2.0.1
+    - 'six>=1.16'
+    - 'apache-superset>=1.5.0,<2.0.0'


### PR DESCRIPTION
Superset was encountering broken packages when installing its virtual environment. Fixing by specifying extra packages and it's versions 