### PR TITLE
fix(conda): add pysus missing depedency

### DIFF
--- a/conda/airflow.yaml
+++ b/conda/airflow.yaml
@@ -24,4 +24,4 @@ dependencies:
   - pip:
     - -r pip.txt
     - epigraphhub
-
+    - pysus


### PR DESCRIPTION
SINAN Dag uses pysus package directly, has to be added into it's dependencies.
![image](https://user-images.githubusercontent.com/82233055/212963162-897e1847-231d-47fb-9194-f70df90bb71a.png)


NOTES:
I noticed this log error in the installation, but the Dags seem to be running alright
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
apache-airflow 2.3.3 requires pathspec~=0.9.0, but you have pathspec 0.10.3 which is incompatible.
``` 