### PR TITLE
fix(sinan-dag): change pysus data path

### DIFF
--- a/containers/airflow/dags/brasil/sinan.py
+++ b/containers/airflow/dags/brasil/sinan.py
@@ -7,6 +7,7 @@ from airflow.decorators import dag, task
 from airflow.operators.empty import EmptyOperator
 
 from epigraphhub.data.brasil.sinan import extract, loading
+from epigraphhub.data._config import PYSUS_DATA_PATH
 
 
 default_args = {
@@ -31,7 +32,7 @@ default_args = {
 def brasil_sinan():
     """
     This DAG will fetch all diseases available on `diseases` from
-    SINAN FTP server. Data will be downloaded at `$HOME/pysus` and then
+    SINAN FTP server. Data will be downloaded at `/tmp/pysus` and then
     pushed into SQL database and the residues will be cleaned.
     @NOTE: This DAG can has a memory overhead that causes instability
            in Airflow System, therefore the max concurrency is set to 2.
@@ -60,7 +61,7 @@ def brasil_sinan():
     @task(task_id='upload')
     def upload_data():
         """
-        This task will upload every disease in the directory ~/pysus
+        This task will upload every disease in the directory /tmp/pysus
         that ends with `.parquet`, creating the corresponding table
         to each disease in `brasil` schema. 
         """        
@@ -73,11 +74,10 @@ def brasil_sinan():
     @task(trigger_rule='all_done')
     def remove_data_dir():
         """ 
-        Cleans ~/pysus data directory.
+        Cleans /tmp/pysus data directory.
         """
-        pysus_data = Path.home() / 'pysus'
-        shutil.rmtree(pysus_data, ignore_errors=True)
-        logger.warning(f'{pysus_data} removed')
+        shutil.rmtree(PYSUS_DATA_PATH, ignore_errors=True)
+        logger.warning(f'{PYSUS_DATA_PATH} removed')
 
 
     # `expand` will create a task for each disease/year.

--- a/containers/airflow/dags/brasil/sinan.py
+++ b/containers/airflow/dags/brasil/sinan.py
@@ -1,6 +1,7 @@
 import shutil
 import pendulum
 import logging as logger
+from pathlib import Path
 from datetime import timedelta
 from airflow.decorators import dag, task
 from airflow.operators.empty import EmptyOperator
@@ -30,7 +31,7 @@ default_args = {
 def brasil_sinan():
     """
     This DAG will fetch all diseases available on `diseases` from
-    SINAN FTP server. Data will be downloaded at `/tmp/pysus` and then
+    SINAN FTP server. Data will be downloaded at `$HOME/pysus` and then
     pushed into SQL database and the residues will be cleaned.
     @NOTE: This DAG can has a memory overhead that causes instability
            in Airflow System, therefore the max concurrency is set to 2.
@@ -53,25 +54,44 @@ def brasil_sinan():
 
         extract.download(disease)
 
-        logger.info(f"Data for {disease} downloaded at /tmp/pysus")
+        logger.info(f"Data for {disease} extracted")
 
 
     @task(task_id='upload')
     def upload_data():
         """
-        Creates table and upsert all data found in `/tmp/pysus/*.parquet`, 
-        cleaning after inserting
+        This task will upload every disease in the directory ~/pysus
+        that ends with `.parquet`, creating the corresponding table
+        to each disease in `brasil` schema. 
         """        
+        try:
+            loading.upload()
+        except Exception as e:
+            logger.error(e)
+            raise e
 
-        loading.upload()
+    @task(trigger_rule='all_done')
+    def remove_data_dir():
+        """ 
+        Cleans ~/pysus data directory.
+        """
+        pysus_data = Path.home() / 'pysus'
+        shutil.rmtree(pysus_data, ignore_errors=True)
+        logger.warning(f'{pysus_data} removed')
 
 
+    # `expand` will create a task for each disease/year.
+    # There will be about 35 diseases total, each disease can
+    # contain several years to fetch, setting `max_active_tasks`
+    # to 2 will allow only two diseases to be downloading at 
+    # the same time
     download = extract_data.expand(disease=list(diseases.keys()))
     
     upload = upload_data()
 
+    clean = remove_data_dir()
 
-    start >> download >> upload >> done 
+    start >> download >> upload >> done >> clean
 
 
 dag = brasil_sinan()


### PR DESCRIPTION
Although the problem of PySUS data not being uploaded into Postgres is not related to the data path, the motive for changing from `/tmp/pysus` to `$HOME/pysus` is because the time the DAG takes to finish. How the workflow is exactly the same to each disease, therefore the usage of `.expand` method, the different amount of years in each disease and the size of some dataframes, accessing each table to extract the total rows would create a huge memory overhead and increase the time for the DAG. Another issue is that `pangres.upsert` method is set to `if_row_exists="update"`, Sandro has told me that some rows are lately updated on SINAN FTP server and the table could have the same amount of rows, but different values in the tables, and that's why all data is downloaded and after deleted monthly.

Requires https://github.com/thegraphnetwork/epigraphhub_py/pull/209 fix to be released 