### PR TITLE
chore(DAG-SINAN): proposal to split DAGs by disease

### DIFF
--- a/containers/airflow/Dockerfile
+++ b/containers/airflow/Dockerfile
@@ -61,6 +61,7 @@ RUN apt-get update -y \
     unixodbc \
     unixodbc-dev \
     yarn \
+    vim \
   && rm -rf /var/lib/apt/lists/* \
     /var/cache/apt/archives \
     /tmp/* \

--- a/containers/airflow/airflow.cfg
+++ b/containers/airflow/airflow.cfg
@@ -316,7 +316,7 @@ encrypt_s3_logs = False
 # Logging level.
 #
 # Supported values: ``CRITICAL``, ``ERROR``, ``WARNING``, ``INFO``, ``DEBUG``.
-logging_level = DEBUG
+logging_level = INFO
 
 # Logging level for celery. If not set, it uses the value of logging_level
 #

--- a/containers/airflow/dags/brasil/sinan.py
+++ b/containers/airflow/dags/brasil/sinan.py
@@ -1,22 +1,23 @@
 import shutil
 import pendulum
+import pandas as pd
 import logging as logger
 
 from glob import glob
+from pysus import SINAN
 from pathlib import Path
 from itertools import cycle
 from datetime import timedelta
 
 from airflow import DAG
-from airflow.decorators import task
-from airflow.operators.empty import EmptyOperator
+from airflow.decorators import task, dag
 
 from epigraphhub.settings import env
 from epigraphhub.connection import get_engine
 from epigraphhub.data._config import PYSUS_DATA_PATH
 from epigraphhub.data.brasil.sinan import (
-    extract, 
-    loading, 
+    extract,
+    loading,
     DISEASES,
     normalize_str,
 )
@@ -24,13 +25,13 @@ from epigraphhub.data.brasil.sinan import (
 ENG = get_engine(credential_name=env.db.default_credential)
 SCHEMA = 'brasil'
 DEFAULT_ARGS = {
-    "owner": "epigraphhub",
-    "depends_on_past": False,
-    "email": ["epigraphhub@thegraphnetwork.org"],
-    "email_on_failure": True,
-    "email_on_retry": False,
-    "retries": 2,
-    "retry_delay": timedelta(minutes=2),
+    'owner': 'epigraphhub',
+    'depends_on_past': False,
+    'email': ['epigraphhub@thegraphnetwork.org'],
+    'email_on_failure': True,
+    'email_on_retry': False,
+    'retries': 2,
+    'retry_delay': timedelta(minutes=2),
 }
 
 
@@ -39,12 +40,14 @@ def task_flow_for(disease: str):
     tablename = 'sinan_' + normalize_str(disease) + '_m'
 
     def _count_table_rows() -> dict:
-        """ 
+        """
         Counts table rows from brasil's Schema
         """
         with ENG.connect() as conn:
             try:
-                cur = conn.execute(f"SELECT COUNT(*) FROM {SCHEMA}.{tablename}")
+                cur = conn.execute(
+                    f'SELECT COUNT(*) FROM {SCHEMA}.{tablename}'
+                )
                 rowcount = cur.fetchone()[0]
             except Exception as e:
                 if 'UndefinedTable' in str(e):
@@ -52,7 +55,6 @@ def task_flow_for(disease: str):
                 else:
                     raise e
         return dict(rows=rowcount)
-
 
     @task(task_id='start')
     def start() -> int:
@@ -62,7 +64,7 @@ def task_flow_for(disease: str):
     @task(task_id='extract', retries=3)
     def download(disease: str) -> list:
         extract.download(disease)
-        logger.info(f"Data for {disease} extracted")
+        logger.info(f'Data for {disease} extracted')
         parquet_dirs = glob(f'{Path(PYSUS_DATA_PATH)/DISEASES[disease]}*')
         return parquet_dirs
 
@@ -79,12 +81,10 @@ def task_flow_for(disease: str):
         ti = kwargs['ti']
         ini_rows_amt = ti.xcom_pull(task_ids='start')
         end_rows_amt = _count_table_rows()
-        
+
         new_rows = end_rows_amt['rows'] - ini_rows_amt['rows']
 
-        logger.info(
-            f'{new_rows} new rows inserted into brasil.{tablename}'
-        )
+        logger.info(f'{new_rows} new rows inserted into brasil.{tablename}')
 
         ti.xcom_push(key='rows', value=ini_rows_amt['rows'])
         ti.xcom_push(key='new_rows', value=new_rows)
@@ -93,7 +93,7 @@ def task_flow_for(disease: str):
     def remove_parquets(**kwargs) -> None:
         ti = kwargs['ti']
         parquet_dirs = ti.xcom_pull(task_ids='extract')
-        
+
         for dir in parquet_dirs:
             shutil.rmtree(dir, ignore_errors=True)
             logger.warning(f'{dir} removed')
@@ -101,10 +101,9 @@ def task_flow_for(disease: str):
     @task(trigger_rule='none_failed')
     def done(**kwargs) -> None:
         ti = kwargs['ti']
-        print(ti.xcom_pull(key='state', task_ids='upload') )
+        print(ti.xcom_pull(key='state', task_ids='upload'))
         if ti.xcom_pull(key='state', task_ids='upload') == 'FAILED':
             raise ValueError('Force failure because upstream task has failed')
-
 
     ini = start()
     E = download(disease)
@@ -128,11 +127,11 @@ def create_dag(
 
     dag = DAG(
         'SINAN_' + DISEASES[disease],
-        default_args=DEFAULT_ARGS, #Tasks and Dags 
-        tags = sinan_tag, #Only DAGs
+        default_args=DEFAULT_ARGS,  # Tasks and Dags
+        tags=sinan_tag,  # Only DAGs
         start_date=start,
         catchup=False,
-        schedule_interval=schedule
+        schedule_interval=schedule,
     )
 
     with dag:
@@ -143,6 +142,40 @@ def create_dag(
 
 # DAGs
 day = cycle(range(1, 29))
+
+
+@dag(
+    'SINAN_METADATA',
+    default_args=DEFAULT_ARGS,
+    tags=['SINAN', 'Brasil', 'Metadata'],
+    start_date=pendulum.datetime(2022, 2, next(day)),
+    catchup=False,
+    schedule_interval='@once',
+)
+def metadata_tables():
+    @task(task_id='insert_metadata_tables')
+    def metadata_tables():
+        for disease in DISEASES:
+            try:
+                metadata_df = SINAN.metadata_df(disease)
+                pd.DataFrame.to_sql(
+                    metadata_df,
+                    f'sinan_{normalize_str(disease)}_metadata',
+                    con=ENG,
+                    schema=SCHEMA,
+                    if_exists='replace',
+                )
+
+                logger.info(f'Metadata table for {disease} updated.')
+            except Exception:
+                print(f'No metadata available for {disease}')
+
+    meta = metadata_tables()
+    meta
+
+
+dag = metadata_tables()
+
 for disease in DISEASES:
     # Change DAG variables here
 
@@ -150,5 +183,5 @@ for disease in DISEASES:
     globals()[dag_id] = create_dag(
         disease,
         schedule='@monthly',
-        start=pendulum.datetime(2022, 2, next(day))
+        start=pendulum.datetime(2022, 2, next(day)),
     )

--- a/containers/airflow/dags/brasil/sinan.py
+++ b/containers/airflow/dags/brasil/sinan.py
@@ -4,6 +4,7 @@ import logging as logger
 
 from glob import glob
 from pathlib import Path
+from itertools import cycle
 from datetime import timedelta
 
 from airflow import DAG
@@ -13,12 +14,11 @@ from airflow.operators.empty import EmptyOperator
 from epigraphhub.settings import env
 from epigraphhub.connection import get_engine
 from epigraphhub.data._config import PYSUS_DATA_PATH
-from epigraphhub.data.brasil.sinan import extract, loading
+from epigraphhub.data.brasil.sinan import extract, loading, DISEASES
 
 
 ENG = get_engine(credential_name=env.db.default_credential)
 SCHEMA = 'brasil'
-DISEASES = extract.diseases
 DEFAULT_ARGS = {
     "owner": "epigraphhub",
     "depends_on_past": False,
@@ -106,353 +106,38 @@ def task_flow_for(disease: str):
     ini >> E >> L >> diagnosis >> clean >> end
 
 
-with DAG(
-    dag_id=DISEASES['Animais Peçonhentos'], 
-    default_args=DEFAULT_ARGS,
-    tags=['Animais Peçonhentos', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 1),
-    catchup=False,
-    schedule_interval='@monthly',
-) as ANIM:
-    task_flow_for('Animais Peçonhentos')
+def create_dag(
+    disease: str,
+    schedule: str,
+    start: pendulum.datetime,
+):
 
-with DAG(
-    dag_id=DISEASES['Cancer'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Cancer', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 2),
-    catchup=False,
-) as CANC:
-    task_flow_for('Cancer')
+    sinan_tag = ['SINAN']
+    sinan_tag.append(disease)
 
-with DAG(
-    dag_id=DISEASES['Botulismo'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Botulismo', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 3),
-    catchup=False,
-) as BOTU:
-    task_flow_for('Botulismo')
+    dag = DAG(
+        'SINAN_' + DISEASES[disease],
+        default_args=DEFAULT_ARGS,
+        tags = sinan_tag,
+        start_date=start,
+        catchup=False,
+        schedule_interval=schedule
+    )
 
-with DAG(
-    dag_id=DISEASES['Chagas'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Chagas', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 4),
-    catchup=False,
-) as CHAG:
-    task_flow_for('Chagas')
+    with dag:
+        task_flow_for(disease)
 
-with DAG(
-    dag_id=DISEASES['Chikungunya'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Chikungunya', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 5),
-    catchup=False,
-) as CHIK:
-    task_flow_for('Chikungunya')    
+    return dag
 
-with DAG(
-    dag_id=DISEASES['Colera'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Colera', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 6),
-    catchup=False,
-) as COLE:
-    task_flow_for('Colera')    
 
-with DAG(
-    dag_id=DISEASES['Coqueluche'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Coqueluche', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 7),
-    catchup=False,
-) as COQU:
-    task_flow_for('Coqueluche') 
+# DAGs
+day = cycle(range(1, 29))
+for disease in DISEASES:
+    # Change DAG variables here
 
-with DAG(
-    dag_id=DISEASES['Contact Communicable Disease'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Contact Communicable Disease', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 8),
-    catchup=False,
-) as ACBI:
-    task_flow_for('Contact Communicable Disease') 
-
-with DAG(
-    dag_id=DISEASES['Acidentes de Trabalho'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Acidentes de Trabalho', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 9),
-    catchup=False,
-) as ACGR:
-    task_flow_for('Acidentes de Trabalho') 
-
-with DAG(
-    dag_id=DISEASES['Dengue'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Dengue', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 10),
-    catchup=False,
-) as DENG:
-    task_flow_for('Dengue') 
-
-with DAG(
-    dag_id=DISEASES['Difteria'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Difteria', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 11),
-    catchup=False,
-) as DIFT:
-    task_flow_for('Difteria') 
-
-with DAG(
-    dag_id=DISEASES['Esquistossomose'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Esquistossomose', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 12),
-    catchup=False,
-) as ESQU:
-    task_flow_for('Esquistossomose') 
- 
-with DAG(
-    dag_id=DISEASES['Febre Amarela'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Febre Amarela', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 13),
-    catchup=False,
-) as FAMA:
-    task_flow_for('Febre Amarela')    
-                 
-with DAG(
-    dag_id=DISEASES['Febre Maculosa'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Febre Maculosa', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 14),
-    catchup=False,
-) as FMAC:
-    task_flow_for('Febre Maculosa')    
-                 
-with DAG(
-    dag_id=DISEASES['Febre Tifoide'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Febre Tifoide', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 15),
-    catchup=False,
-) as FTIF:
-    task_flow_for('Febre Tifoide')    
-        
-with DAG(
-    dag_id=DISEASES['Hanseniase'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Hanseniase', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 16),
-    catchup=False,
-) as HANS:
-    task_flow_for('Hanseniase')    
-         
-with DAG(
-    dag_id=DISEASES['Hantavirose'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Hantavirose', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 17),
-    catchup=False,
-) as HANT:
-    task_flow_for('Hantavirose')    
-         
-with DAG(
-    dag_id=DISEASES['Hepatites Virais'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Hepatites Virais', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 18),
-    catchup=False,
-) as HEPA:
-    task_flow_for('Hepatites Virais')    
-         
-with DAG(
-    dag_id=DISEASES['Intoxicação Exógena'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Intoxicação Exógena', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 19),
-    catchup=False,
-) as IEXO:
-    task_flow_for('Intoxicação Exógena')    
-         
-with DAG(
-    dag_id=DISEASES['Leishmaniose Visceral'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Leishmaniose Visceral', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 20),
-    catchup=False,
-) as LEIV:
-    task_flow_for('Leishmaniose Visceral')    
-        
-with DAG(
-    dag_id=DISEASES['Leptospirose'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Leptospirose', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 21),
-    catchup=False,
-) as LEPT:
-    task_flow_for('Leptospirose')    
-        
-with DAG(
-    dag_id=DISEASES['Leishmaniose Tegumentar'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Leishmaniose Tegumentar', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 22),
-    catchup=False,
-) as LTAN:
-    task_flow_for('Leishmaniose Tegumentar')    
-        
-with DAG(
-    dag_id=DISEASES['Malaria'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Malaria', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 23),
-    catchup=False,
-) as MALA:
-    task_flow_for('Malaria')    
-        
-with DAG(
-    dag_id=DISEASES['Meningite'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Meningite', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 24),
-    catchup=False,
-) as MENI:
-    task_flow_for('Meningite')    
-         
-with DAG(
-    dag_id=DISEASES['Peste'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Peste', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 25),
-    catchup=False,
-) as PEST:
-    task_flow_for('Peste')    
-         
-with DAG(
-    dag_id=DISEASES['Poliomielite'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Poliomielite', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 26),
-    catchup=False,
-) as PFAN:
-    task_flow_for('Poliomielite')    
-        
-with DAG(
-    dag_id=DISEASES['Raiva Humana'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Raiva Humana', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 27),
-    catchup=False,
-) as RAIV:
-    task_flow_for('Raiva Humana')    
-        
-with DAG(
-    dag_id=DISEASES['Sífilis Adquirida'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Sífilis Adquirida', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 1),
-    catchup=False,
-) as SIFA:
-    task_flow_for('Sífilis Adquirida')    
-         
-with DAG(
-    dag_id=DISEASES['Sífilis Congênita'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Sífilis Congênita', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 2),
-    catchup=False,
-) as SIFC:
-    task_flow_for('Sífilis Congênita')    
-        
-with DAG(
-    dag_id=DISEASES['Sífilis em Gestante'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Sífilis em Gestante', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 3),
-    catchup=False,
-) as SIFG:
-    task_flow_for('Sífilis em Gestante')    
-        
-with DAG(
-    dag_id=DISEASES['Tétano Acidental'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Tétano Acidental', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 4),
-    catchup=False,
-) as TETA:
-    task_flow_for('Tétano Acidental')    
-         
-with DAG(
-    dag_id=DISEASES['Tétano Neonatal'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Tétano Neonatal', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 5),
-    catchup=False,
-) as TETN:
-    task_flow_for('Tétano Neonatal')    
-        
-with DAG(
-    dag_id=DISEASES['Tuberculose'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Tuberculose', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 6),
-    catchup=False,
-) as TUBE:
-    task_flow_for('Tuberculose')    
-         
-with DAG(
-    dag_id=DISEASES['Violência Domestica'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Violência Domestica', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 7),
-    catchup=False,
-) as VIOL:
-    task_flow_for('Violência Domestica')    
-        
-with DAG(
-    dag_id=DISEASES['Zika'], 
-    schedule_interval='@monthly',
-    default_args=DEFAULT_ARGS,
-    tags=['Zika', 'SINAN'],
-    start_date= pendulum.datetime(2022, 2, 8),
-    catchup=False,
-) as ZIKA:
-    task_flow_for('Zika')    
-        
+    dag_id = 'SINAN_' + DISEASES[disease]
+    globals()[dag_id] = create_dag(
+        disease,
+        schedule='@monthly',
+        start=pendulum.datetime(2022, 2, next(day))
+    )

--- a/containers/airflow/dags/brasil/sinan.py
+++ b/containers/airflow/dags/brasil/sinan.py
@@ -19,7 +19,6 @@ from epigraphhub.data.brasil.sinan import extract, loading
 ENG = get_engine(credential_name=env.db.default_credential)
 SCHEMA = 'brasil'
 DISEASES = extract.diseases
-TAGS = ["BRA","PySUS", "SINAN"]
 DEFAULT_ARGS = {
     "owner": "epigraphhub",
     "depends_on_past": False,
@@ -110,7 +109,7 @@ def task_flow_for(disease: str):
 with DAG(
     dag_id=DISEASES['Animais Peçonhentos'], 
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Animais Peçonhentos', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 1),
     catchup=False,
     schedule_interval='@monthly',
@@ -121,7 +120,7 @@ with DAG(
     dag_id=DISEASES['Cancer'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Cancer', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 2),
     catchup=False,
 ) as CANC:
@@ -131,7 +130,7 @@ with DAG(
     dag_id=DISEASES['Botulismo'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Botulismo', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 3),
     catchup=False,
 ) as BOTU:
@@ -141,7 +140,7 @@ with DAG(
     dag_id=DISEASES['Chagas'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Chagas', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 4),
     catchup=False,
 ) as CHAG:
@@ -151,7 +150,7 @@ with DAG(
     dag_id=DISEASES['Chikungunya'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Chikungunya', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 5),
     catchup=False,
 ) as CHIK:
@@ -161,7 +160,7 @@ with DAG(
     dag_id=DISEASES['Colera'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Colera', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 6),
     catchup=False,
 ) as COLE:
@@ -171,7 +170,7 @@ with DAG(
     dag_id=DISEASES['Coqueluche'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Coqueluche', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 7),
     catchup=False,
 ) as COQU:
@@ -181,7 +180,7 @@ with DAG(
     dag_id=DISEASES['Contact Communicable Disease'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Contact Communicable Disease', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 8),
     catchup=False,
 ) as ACBI:
@@ -191,7 +190,7 @@ with DAG(
     dag_id=DISEASES['Acidentes de Trabalho'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Acidentes de Trabalho', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 9),
     catchup=False,
 ) as ACGR:
@@ -201,7 +200,7 @@ with DAG(
     dag_id=DISEASES['Dengue'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Dengue', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 10),
     catchup=False,
 ) as DENG:
@@ -211,7 +210,7 @@ with DAG(
     dag_id=DISEASES['Difteria'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Difteria', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 11),
     catchup=False,
 ) as DIFT:
@@ -221,7 +220,7 @@ with DAG(
     dag_id=DISEASES['Esquistossomose'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Esquistossomose', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 12),
     catchup=False,
 ) as ESQU:
@@ -231,7 +230,7 @@ with DAG(
     dag_id=DISEASES['Febre Amarela'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Febre Amarela', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 13),
     catchup=False,
 ) as FAMA:
@@ -241,7 +240,7 @@ with DAG(
     dag_id=DISEASES['Febre Maculosa'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Febre Maculosa', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 14),
     catchup=False,
 ) as FMAC:
@@ -251,7 +250,7 @@ with DAG(
     dag_id=DISEASES['Febre Tifoide'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Febre Tifoide', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 15),
     catchup=False,
 ) as FTIF:
@@ -261,7 +260,7 @@ with DAG(
     dag_id=DISEASES['Hanseniase'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Hanseniase', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 16),
     catchup=False,
 ) as HANS:
@@ -271,7 +270,7 @@ with DAG(
     dag_id=DISEASES['Hantavirose'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Hantavirose', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 17),
     catchup=False,
 ) as HANT:
@@ -281,7 +280,7 @@ with DAG(
     dag_id=DISEASES['Hepatites Virais'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Hepatites Virais', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 18),
     catchup=False,
 ) as HEPA:
@@ -291,7 +290,7 @@ with DAG(
     dag_id=DISEASES['Intoxicação Exógena'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Intoxicação Exógena', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 19),
     catchup=False,
 ) as IEXO:
@@ -301,7 +300,7 @@ with DAG(
     dag_id=DISEASES['Leishmaniose Visceral'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Leishmaniose Visceral', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 20),
     catchup=False,
 ) as LEIV:
@@ -311,7 +310,7 @@ with DAG(
     dag_id=DISEASES['Leptospirose'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Leptospirose', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 21),
     catchup=False,
 ) as LEPT:
@@ -321,7 +320,7 @@ with DAG(
     dag_id=DISEASES['Leishmaniose Tegumentar'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Leishmaniose Tegumentar', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 22),
     catchup=False,
 ) as LTAN:
@@ -331,7 +330,7 @@ with DAG(
     dag_id=DISEASES['Malaria'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Malaria', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 23),
     catchup=False,
 ) as MALA:
@@ -341,7 +340,7 @@ with DAG(
     dag_id=DISEASES['Meningite'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Meningite', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 24),
     catchup=False,
 ) as MENI:
@@ -351,7 +350,7 @@ with DAG(
     dag_id=DISEASES['Peste'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Peste', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 25),
     catchup=False,
 ) as PEST:
@@ -361,7 +360,7 @@ with DAG(
     dag_id=DISEASES['Poliomielite'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Poliomielite', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 26),
     catchup=False,
 ) as PFAN:
@@ -371,7 +370,7 @@ with DAG(
     dag_id=DISEASES['Raiva Humana'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Raiva Humana', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 27),
     catchup=False,
 ) as RAIV:
@@ -381,7 +380,7 @@ with DAG(
     dag_id=DISEASES['Sífilis Adquirida'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Sífilis Adquirida', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 1),
     catchup=False,
 ) as SIFA:
@@ -391,7 +390,7 @@ with DAG(
     dag_id=DISEASES['Sífilis Congênita'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Sífilis Congênita', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 2),
     catchup=False,
 ) as SIFC:
@@ -401,7 +400,7 @@ with DAG(
     dag_id=DISEASES['Sífilis em Gestante'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Sífilis em Gestante', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 3),
     catchup=False,
 ) as SIFG:
@@ -411,7 +410,7 @@ with DAG(
     dag_id=DISEASES['Tétano Acidental'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Tétano Acidental', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 4),
     catchup=False,
 ) as TETA:
@@ -421,7 +420,7 @@ with DAG(
     dag_id=DISEASES['Tétano Neonatal'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Tétano Neonatal', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 5),
     catchup=False,
 ) as TETN:
@@ -431,7 +430,7 @@ with DAG(
     dag_id=DISEASES['Tuberculose'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Tuberculose', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 6),
     catchup=False,
 ) as TUBE:
@@ -441,7 +440,7 @@ with DAG(
     dag_id=DISEASES['Violência Domestica'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Violência Domestica', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 7),
     catchup=False,
 ) as VIOL:
@@ -451,7 +450,7 @@ with DAG(
     dag_id=DISEASES['Zika'], 
     schedule_interval='@monthly',
     default_args=DEFAULT_ARGS,
-    tags=TAGS,
+    tags=['Zika', 'SINAN'],
     start_date= pendulum.datetime(2022, 2, 8),
     catchup=False,
 ) as ZIKA:

--- a/containers/airflow/dags/brasil/sinan.py
+++ b/containers/airflow/dags/brasil/sinan.py
@@ -93,7 +93,7 @@ def task_flow_for(disease: str):
 
     done = EmptyOperator(
         task_id="done",
-        trigger_rule="all_success",
+        trigger_rule="none_failed",
     )
 
     ini = start(disease)

--- a/containers/airflow/dags/brasil/sinan.py
+++ b/containers/airflow/dags/brasil/sinan.py
@@ -123,11 +123,12 @@ def create_dag(
 
     sinan_tag = ['SINAN', 'Brasil']
     sinan_tag.append(disease)
+    DEFAULT_ARGS.update(start_date=start)
 
     dag = DAG(
         'SINAN_' + DISEASES[disease],
-        default_args=DEFAULT_ARGS,
-        tags = sinan_tag,
+        default_args=DEFAULT_ARGS, #Tasks and Dags 
+        tags = sinan_tag, #Only DAGs
         start_date=start,
         catchup=False,
         schedule_interval=schedule

--- a/containers/airflow/dags/brasil/sinan.py
+++ b/containers/airflow/dags/brasil/sinan.py
@@ -1,21 +1,28 @@
 import shutil
 import pendulum
 import logging as logger
+
+from glob import glob
 from pathlib import Path
 from datetime import timedelta
-from airflow.decorators import dag, task
+
+from airflow import DAG
+from airflow.decorators import task
 from airflow.operators.empty import EmptyOperator
 
-from epigraphhub.data.brasil.sinan import extract, loading
-from epigraphhub.data._config import PYSUS_DATA_PATH
-from epigraphhub.connection import get_engine
 from epigraphhub.settings import env
+from epigraphhub.connection import get_engine
+from epigraphhub.data._config import PYSUS_DATA_PATH
+from epigraphhub.data.brasil.sinan import extract, loading
 
 
-default_args = {
+ENG = get_engine(credential_name=env.db.default_credential)
+SCHEMA = 'brasil'
+DISEASES = extract.diseases
+TAGS = ["BRA","PySUS", "SINAN"]
+DEFAULT_ARGS = {
     "owner": "epigraphhub",
     "depends_on_past": False,
-    "start_date": pendulum.datetime(2022, 12, 1),
     "email": ["epigraphhub@thegraphnetwork.org"],
     "email_on_failure": True,
     "email_on_retry": False,
@@ -24,116 +31,429 @@ default_args = {
 }
 
 
-@dag(
-    schedule_interval="@monthly",
-    default_args=default_args,
-    catchup=False,
-    max_active_runs=2,
-    max_active_tasks=2,
-)
-def brasil_sinan():
-    """
-    This DAG will fetch all diseases available on `diseases` from
-    SINAN FTP server. Data will be downloaded at `/tmp/pysus` and then
-    pushed into SQL database and the residues will be cleaned.
-    @NOTE: This DAG can has a memory overhead that causes instability
-           in Airflow System, therefore the max concurrency is set to 2.
-    """
-
-    engine = get_engine(credential_name=env.db.default_credential)
-    diseases = extract.diseases
-
-    def count_tables_rows() -> dict:
+def task_flow_for(disease: str):
+    def _count_table_rows(engine, table: str) -> int:
         """ 
-        Counts table rows for each disease in diseases.
+        Counts table rows from brasil's Schema
         """
-        totals = {v: k for k, v in diseases.items()}
         with engine.connect() as conn:
-            for disease in totals:
-                try:
-                    cur = conn.execute(f"SELECT COUNT(*) FROM brasil.{disease.lower()}")
-                    rowcount = cur.fetchone()[0]
-                    totals.update({disease:rowcount})
-                except Exception as e:
-                    if 'UndefinedTable' in str(e):
-                        totals.update({disease:0})
-                    else:
-                        raise e
-        return totals
-
+            try:
+                cur = conn.execute(f"SELECT COUNT(*) FROM {SCHEMA}.{table}")
+                rowcount = cur.fetchone()[0]
+            except Exception as e:
+                if 'UndefinedTable' in str(e):
+                    return 0
+                else:
+                    raise e
+        return rowcount
 
     @task(task_id='start')
-    def start() -> dict:
-        return count_tables_rows()
+    def start(disease: str) -> int:
+        logger.info(f'ETL started for {disease}')
+        return _count_table_rows(ENG, DISEASES[disease].lower())
 
+    @task(task_id='extract', retries=3)
+    def download(disease: str) -> list:
+        extract.download(disease)
+        logger.info(f"Data for {disease} extracted")
+        parquet_dirs = glob(f'{Path(PYSUS_DATA_PATH)/DISEASES[disease]}*')
+        return parquet_dirs
+
+    @task(task_id='upload')
+    def upload(**kwargs) -> None:
+        ti = kwargs['ti']
+        parquet_dirs = ti.xcom_pull(task_ids='extract')
+        try:
+            loading.upload(parquet_dirs)
+        except Exception as e:
+            logger.error(e)
+            raise e
+
+    @task(task_id='diagnosis')
+    def compare_tables_rows(disease: str, **kwargs) -> int:
+        ti = kwargs['ti']
+        ini_rows_amt = ti.xcom_pull(task_ids='start')
+        end_rows_amt = _count_table_rows(ENG, DISEASES[disease].lower())
+        
+        new_rows = end_rows_amt - ini_rows_amt
+
+        logger.info(
+            f'{new_rows} new rows inserted into brasil.{disease}'
+        )
+
+        return new_rows
+
+    @task(trigger_rule='all_done')
+    def remove_parquets(**kwargs) -> None:
+        ti = kwargs['ti']
+        parquet_dirs = ti.xcom_pull(task_ids='extract')
+        
+        for dir in parquet_dirs:
+            shutil.rmtree(dir, ignore_errors=True)
+            logger.warning(f'{dir} removed')
 
     done = EmptyOperator(
         task_id="done",
         trigger_rule="all_success",
     )
 
+    ini = start(disease)
+    E = download(disease)
+    L = upload()
+    diagnosis = compare_tables_rows(disease)
+    clean = remove_parquets()
+    end = done
 
-    @task(task_id='extract', retries=3)
-    def extract_data(disease) -> None:
-        # Downloads an disease according to `diseases`.
-
-        extract.download(disease)
-
-        logger.info(f"Data for {disease} extracted")
-
-
-    @task(task_id='upload')
-    def upload_data() -> None:
-        """
-        This task will upload every disease in the directory /tmp/pysus
-        that ends with `.parquet`, creating the corresponding table
-        to each disease in `brasil` schema. 
-        """        
-        try:
-            loading.upload()
-        except Exception as e:
-            logger.error(e)
-            raise e
+    ini >> E >> L >> diagnosis >> clean >> end
 
 
-    @task(task_id='diagnosis')
-    def compare_tables_rows(**kwargs) -> None:
-        ti = kwargs['ti']
-        ini_rows_amt = ti.xcom_pull(task_ids='start')
-        end_rows_amt = count_tables_rows()
+with DAG(
+    dag_id=DISEASES['Animais Peçonhentos'], 
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 1),
+    catchup=False,
+    schedule_interval='@monthly',
+) as ANIM:
+    task_flow_for('Animais Peçonhentos')
+
+with DAG(
+    dag_id=DISEASES['Cancer'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 2),
+    catchup=False,
+) as CANC:
+    task_flow_for('Cancer')
+
+with DAG(
+    dag_id=DISEASES['Botulismo'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 3),
+    catchup=False,
+) as BOTU:
+    task_flow_for('Botulismo')
+
+with DAG(
+    dag_id=DISEASES['Chagas'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 4),
+    catchup=False,
+) as CHAG:
+    task_flow_for('Chagas')
+
+with DAG(
+    dag_id=DISEASES['Chikungunya'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 5),
+    catchup=False,
+) as CHIK:
+    task_flow_for('Chikungunya')    
+
+with DAG(
+    dag_id=DISEASES['Colera'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 6),
+    catchup=False,
+) as COLE:
+    task_flow_for('Colera')    
+
+with DAG(
+    dag_id=DISEASES['Coqueluche'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 7),
+    catchup=False,
+) as COQU:
+    task_flow_for('Coqueluche') 
+
+with DAG(
+    dag_id=DISEASES['Contact Communicable Disease'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 8),
+    catchup=False,
+) as ACBI:
+    task_flow_for('Contact Communicable Disease') 
+
+with DAG(
+    dag_id=DISEASES['Acidentes de Trabalho'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 9),
+    catchup=False,
+) as ACGR:
+    task_flow_for('Acidentes de Trabalho') 
+
+with DAG(
+    dag_id=DISEASES['Dengue'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 10),
+    catchup=False,
+) as DENG:
+    task_flow_for('Dengue') 
+
+with DAG(
+    dag_id=DISEASES['Difteria'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 11),
+    catchup=False,
+) as DIFT:
+    task_flow_for('Difteria') 
+
+with DAG(
+    dag_id=DISEASES['Esquistossomose'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 12),
+    catchup=False,
+) as ESQU:
+    task_flow_for('Esquistossomose') 
+ 
+with DAG(
+    dag_id=DISEASES['Febre Amarela'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 13),
+    catchup=False,
+) as FAMA:
+    task_flow_for('Febre Amarela')    
+                 
+with DAG(
+    dag_id=DISEASES['Febre Maculosa'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 14),
+    catchup=False,
+) as FMAC:
+    task_flow_for('Febre Maculosa')    
+                 
+with DAG(
+    dag_id=DISEASES['Febre Tifoide'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 15),
+    catchup=False,
+) as FTIF:
+    task_flow_for('Febre Tifoide')    
         
-        for disease in ini_rows_amt:
-            logger.info(
-                f'{end_rows_amt[disease] - ini_rows_amt[disease]}'
-                f' new rows inserted into brasil.{disease}'
-            )
-
-
-    @task(trigger_rule='all_done')
-    def remove_data_dir() -> None:
-        """ 
-        Cleans /tmp/pysus data directory.
-        """
-        shutil.rmtree(PYSUS_DATA_PATH, ignore_errors=True)
-        logger.warning(f'{PYSUS_DATA_PATH} removed')
-
-
-    init = start()
-
-    # `expand` will create a task for each disease/year.
-    # There will be about 35 diseases total, each disease can
-    # contain several years to fetch, setting `max_active_tasks`
-    # to 2 will allow only two diseases to be downloading at 
-    # the same time
-    download = extract_data.expand(disease=list(diseases.keys()))
-    
-    upload = upload_data()
-
-    diagnosis = compare_tables_rows()
-
-    clean = remove_data_dir()
-
-    init >> download >> upload >> diagnosis >> done >> clean
-
-
-dag = brasil_sinan()
+with DAG(
+    dag_id=DISEASES['Hanseniase'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 16),
+    catchup=False,
+) as HANS:
+    task_flow_for('Hanseniase')    
+         
+with DAG(
+    dag_id=DISEASES['Hantavirose'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 17),
+    catchup=False,
+) as HANT:
+    task_flow_for('Hantavirose')    
+         
+with DAG(
+    dag_id=DISEASES['Hepatites Virais'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 18),
+    catchup=False,
+) as HEPA:
+    task_flow_for('Hepatites Virais')    
+         
+with DAG(
+    dag_id=DISEASES['Intoxicação Exógena'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 19),
+    catchup=False,
+) as IEXO:
+    task_flow_for('Intoxicação Exógena')    
+         
+with DAG(
+    dag_id=DISEASES['Leishmaniose Visceral'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 20),
+    catchup=False,
+) as LEIV:
+    task_flow_for('Leishmaniose Visceral')    
+        
+with DAG(
+    dag_id=DISEASES['Leptospirose'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 21),
+    catchup=False,
+) as LEPT:
+    task_flow_for('Leptospirose')    
+        
+with DAG(
+    dag_id=DISEASES['Leishmaniose Tegumentar'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 22),
+    catchup=False,
+) as LTAN:
+    task_flow_for('Leishmaniose Tegumentar')    
+        
+with DAG(
+    dag_id=DISEASES['Malaria'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 23),
+    catchup=False,
+) as MALA:
+    task_flow_for('Malaria')    
+        
+with DAG(
+    dag_id=DISEASES['Meningite'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 24),
+    catchup=False,
+) as MENI:
+    task_flow_for('Meningite')    
+         
+with DAG(
+    dag_id=DISEASES['Peste'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 25),
+    catchup=False,
+) as PEST:
+    task_flow_for('Peste')    
+         
+with DAG(
+    dag_id=DISEASES['Poliomielite'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 26),
+    catchup=False,
+) as PFAN:
+    task_flow_for('Poliomielite')    
+        
+with DAG(
+    dag_id=DISEASES['Raiva Humana'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 27),
+    catchup=False,
+) as RAIV:
+    task_flow_for('Raiva Humana')    
+        
+with DAG(
+    dag_id=DISEASES['Sífilis Adquirida'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 1),
+    catchup=False,
+) as SIFA:
+    task_flow_for('Sífilis Adquirida')    
+         
+with DAG(
+    dag_id=DISEASES['Sífilis Congênita'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 2),
+    catchup=False,
+) as SIFC:
+    task_flow_for('Sífilis Congênita')    
+        
+with DAG(
+    dag_id=DISEASES['Sífilis em Gestante'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 3),
+    catchup=False,
+) as SIFG:
+    task_flow_for('Sífilis em Gestante')    
+        
+with DAG(
+    dag_id=DISEASES['Tétano Acidental'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 4),
+    catchup=False,
+) as TETA:
+    task_flow_for('Tétano Acidental')    
+         
+with DAG(
+    dag_id=DISEASES['Tétano Neonatal'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 5),
+    catchup=False,
+) as TETN:
+    task_flow_for('Tétano Neonatal')    
+        
+with DAG(
+    dag_id=DISEASES['Tuberculose'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 6),
+    catchup=False,
+) as TUBE:
+    task_flow_for('Tuberculose')    
+         
+with DAG(
+    dag_id=DISEASES['Violência Domestica'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 7),
+    catchup=False,
+) as VIOL:
+    task_flow_for('Violência Domestica')    
+        
+with DAG(
+    dag_id=DISEASES['Zika'], 
+    schedule_interval='@monthly',
+    default_args=DEFAULT_ARGS,
+    tags=TAGS,
+    start_date= pendulum.datetime(2022, 2, 8),
+    catchup=False,
+) as ZIKA:
+    task_flow_for('Zika')    
+        

--- a/containers/airflow/dags/brasil/sinan.py
+++ b/containers/airflow/dags/brasil/sinan.py
@@ -121,7 +121,7 @@ def create_dag(
     start: pendulum.datetime,
 ):
 
-    sinan_tag = ['SINAN']
+    sinan_tag = ['SINAN', 'Brasil']
     sinan_tag.append(disease)
 
     dag = DAG(

--- a/containers/airflow/dags/foph_dag.py
+++ b/containers/airflow/dags/foph_dag.py
@@ -98,6 +98,7 @@ default_args = {
     schedule_interval="@weekly",
     default_args=default_args,
     catchup=False,
+    tags = ['CHE', 'FOPH']
 )
 def foph():
     """

--- a/containers/airflow/dags/foph_dag.py
+++ b/containers/airflow/dags/foph_dag.py
@@ -98,7 +98,7 @@ default_args = {
     schedule_interval="@weekly",
     default_args=default_args,
     catchup=False,
-    tags = ['CHE', 'FOPH']
+    tags = ['CHE', 'FOPH', 'Switzerland']
 )
 def foph():
     """

--- a/containers/airflow/dags/owid_dag.py
+++ b/containers/airflow/dags/owid_dag.py
@@ -82,6 +82,7 @@ default_args = {
     schedule_interval="@daily",
     default_args=default_args,
     catchup=False,
+    tags=['OWID']
 )
 def owid():
     """


### PR DESCRIPTION
# PROPOSTAL
 Change SINAN DAG by each disease instead of heaving one centralized DAG for the 36 diseases

## Motivations
- Some diseases take hours to fetch, having 35 running in the same DAG can take almost an entire day to fetch even with some concurrency, while some diseases take less than 10 minutes to insert the data.
![image](https://user-images.githubusercontent.com/82233055/218891242-6c00934f-a3e4-4f74-9c1f-a7b091b07097.png)
- Lack of schedule control. Having one DAG to all diseases, it is not possible to reduce or increase the schedule between each DAG run, creating an unnecessary bound between the diseases.
- Not scalable. I've notice the amount of diseases in SINAN may grow with time, which can increase even more the time the entire process takes to finish.
- High "breakability". The bound caused by the method `expand` (which loops between the diseases to fetch) is great because there is no need to consider how many diseases the DAG receives, but also creates a waterfall of errors if a disease stops working for any reason.
OBS:
Creating an task branch for each disease (as done in FOPH DAG) is unlikely to be an option due to the amount of diseases, it is very difficult to scroll down while DEBUGGING, because there will be a lot of tasks in the GUI.

## Cons
- Significantly increase of DAGs in the GUI. It is also not possible to use non-ASCII characters in the DAG's name. A good workaround is to define properly tags for each DAG created so it can be easily seached. The result follows:
![image](https://user-images.githubusercontent.com/82233055/218893646-f728fd32-3937-4ca6-b33d-998be0d2475d.png)

----
depends on https://github.com/thegraphnetwork/epigraphhub_py/pull/211