### PR TITLE
chore(improvement): Implement makim and containers-sugar

### DIFF
--- a/.containers-sugar.yaml
+++ b/.containers-sugar.yaml
@@ -1,0 +1,31 @@
+version: 1.0.0
+compose-app: docker-compose
+service-groups:
+  - name: default
+    project-name: egh-prod
+    compose-path:
+      - containers/compose-base.yaml
+      - containers/compose-prod.yaml
+    env-file: .env
+    services:
+      default: superset,airflow
+      list:
+        - name: redis
+        - name: flower
+        - name: minio
+        - name: superset
+        - name: airflow
+        - name: postgres
+        
+  - name: dev
+    project-name: egh-dev
+    compose-path: 
+      - containers/compose-base.yaml
+      - containers/compose-dev.yaml
+    env-file: .env
+    services: superset,airflow
+      default: 
+      list:
+        - name: superset
+        - name: airflow
+        - name: postgres

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -73,7 +73,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: setup
-      run: make prepare-host
+      run: makim host.prepare
 
     - name: Create environment variables file
       run: |
@@ -97,26 +97,26 @@ jobs:
           --db-uri "${POSTGRES_EPIGRAPH_USER}:${POSTGRES_EPIGRAPH_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_EPIGRAPH_DB}"
 
     - name: configure aws s3 credentials to minio
-      run: make dev-create-s3-credential
+      run: makim aws.dev-create-s3-credential
 
-    - name: build docker containers
-      run: make containers-build
+    - name: build containers-sugar
+      run: containers-sugar build
 
     - name: start services
       run: |
-        make containers-start-services SERVICES="superset airflow"
+        makim containers.start-services --services "superset,airflow"
 
     - name: wait for the services are properly working
       run: |
         docker ps
-        make containers-wait-all
+        makim containers.wait-all
 
     - name: Trigger all DAGs
       run: |
-        make containers-exec ARGS="-T" SERVICE=airflow CMD='airflow dags test owid 2022-10-25'
-        make containers-exec ARGS="-T" SERVICE=airflow CMD='airflow dags test foph 2022-10-25'
-        make containers-exec ARGS="-T" SERVICE=airflow CMD='airflow dags test colombia 2022-10-25'
-        make containers-exec ARGS="-T" SERVICE=airflow CMD='airflow dags test web_status_test 2022-10-25'
+        containers-sugar exec --extras="-T" --services airflow --cmd 'airflow dags test owid 2022-10-25' 
+        containers-sugar exec --extras="-T" --services airflow --cmd 'airflow dags test foph 2022-10-25'
+        containers-sugar exec --args="-T" --services airflow --cmd 'airflow dags test colombia 2022-10-25'
+        containers-sugar exec --extra="-T" --services airflow --cmd 'airflow dags test web_status_test 2022-10-25'
 
     - name: Test MinIO access
       run: aws --endpoint-url http://localhost:9000/ s3 ls
@@ -124,9 +124,9 @@ jobs:
     - name: Generate logs
       if: ${{ failure() }}
       run: |
-        make containers-logs ARGS="--tail 1000" SERVICES="" > /tmp/containers-services.log
+        makim containers-sugar logs --extras "--tail 1000" --all > /tmp/containers-services.log
 
-    - name: Archive log artifacts
+- name: Archive log artifacts
       uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:

--- a/.makim.yaml
+++ b/.makim.yaml
@@ -1,0 +1,82 @@
+version: 1.0.0
+env-file: .env
+groups:
+
+  host:
+    targets:
+      prepare:
+        help: Preparing host
+        run: |
+          bash scripts/prepare-host.sh
+    
+  aws:
+    targets:
+      dev-create-s3-credential:
+        help: Create AWS S3 Credentials
+        run: |
+          set -e
+          ./scripts/dev/create-s3-credential.sh
+
+  
+  conda:
+    targets:
+      lock:
+        help: Configure a conda-lock
+        run: |
+          cd conda
+          rm -f conda-*.lock
+          conda-lock --conda which mamba \
+              -f prod.yaml  \
+              -p osx-64 \
+              -p linux-64 \
+              --kind explicit
+
+  containers:
+    targets:
+      wait:
+        help: Wait for a service
+        args:
+          timeout:
+            help: Define the timeout for the healthcheck
+            type: integer
+            default: 30
+          service:
+            help: Service name that would be awaited
+            type: string
+            required: True
+
+        run: |
+          timeout {{ args.timeout }} ./containers/scripts/healthcheck.sh {{ args.service }}
+          
+      wait-all:
+        run: |
+          if $ENV == "dev":
+            makim containers.wait --service "postgres"
+
+          for service in ["postgres","airflow","superset","redis","flower","minio"]:
+            makim containers.wait --service @(service)
+
+      start-services:
+        help: bla
+        shell: bash
+        dependencies:
+          - targets: host.prepare
+        args:
+          services: Services names separated by comma
+            help: 
+            type: string
+            default: "airflow,superset"
+
+        run: |
+          set -e
+          if [ "${ENV}" = "dev" ]; then \
+            containers-sugar start --services "postgres"; \
+            makim containers.wait --service "postgres"; \
+          fi
+          containers-sugar start --services {{ args.services }}
+          makim containers.wait --service "airflow"
+
+      dev-prepare-db:
+        help: Prepare a database. Used for development
+        run: |
+          containers-sugar exec --extras="-T" --services superset   --cmd "bash /opt/EpiGraphHub/containers/postgresql/scripts/dev/prepare-db.sh"

--- a/README.md
+++ b/README.md
@@ -166,26 +166,26 @@ $ conda activate epigraphhub
 
 ![fig2](https://user-images.githubusercontent.com/140123/165057193-c5a2b2a2-8f30-426d-9bac-8f559c01265d.png)
 
-The project provides three **compose** files, where one is the base
-definition (`containers/compose-base.yaml`) and the others are one for
-development (`containers/compose-dev.yaml`) and other for production
-(`containers/compose-prod.yaml`). Additionally, there is a **Makefile**
-file that provides `make` targets that helps to manage the docker services:
+The project provides three **compose** files, where one is the base definition
+(`containers/compose-base.yaml`) and the others are one for development
+(`containers/compose-dev.yaml`) and other for production
+(`containers/compose-prod.yaml`). Additionally, there is a **.makim.yaml** file
+that provides `makim` targets that helps to define targets and dependencies and a
+**.containers.sugar.yaml** file that provides `containers-sugar` commands to
+manage the usage of containers:
 
-- `containers-build`: builds docker images
-- `containers-start`: starts docker services
-- `containers-stop`: stops docker services
-- `containers-restart`: restarts docker services
-- `containers-logs`: shows docker
-- `containers-dev-prepare-db`: prepares the development version of the database
-- `containers-run-cron`: run the cron tasks
-- `containers-bash`: opens the docker service bash
+- `containers-sugar build`: builds docker images
+- `containers-sugar start`: starts docker services
+- `containers-sugar stop`: stops docker services
+- `containers-sugar restart`: restarts docker services
+- `containers-sugar logs`: shows docker
+- `makim containers.dev-prepare-db`: prepares the development version of the database
 
-This `make` targets runs by default docker for development. For production,
+This `makim` targets runs by default docker for development. For production,
 it is necessary to pass the argument `ENV=prod` , for example:
 
 ```bash
-make containers-build
+makim containers-sugar build
 ```
 
 A common workflow to prepare the system would be:
@@ -193,13 +193,13 @@ A common workflow to prepare the system would be:
 1. Build the docker image:
 
 ```bash
-$ make containers-build
+$ containers-sugar build
 ```
 
 2. Start the services:
 
 ```bash
-$ make containers-start
+$ containers-sugar start
 ```
 
 Before moving forward, check if the services are working properly:
@@ -211,7 +211,7 @@ $ ./containers/healthcheck.sh epigraphhub
 3. Now, prepare the development database (skip it for production):
 
 ```bash
-$ make containers-prepare-db
+$ makim containers.dev-prepare-db
 ```
 
 ## AIRFLOW
@@ -231,7 +231,7 @@ For development, it is already created by the containers stack.
 In order to configure it locally, run:
 
 ```bash
-make dev-create-s3-credentials
+makim aws.dev-create-s3-credentials
 ```
 
 Note: it needs the AWS env variable on the environment (or from .env file).

--- a/conda/base.yaml
+++ b/conda/base.yaml
@@ -12,3 +12,5 @@ dependencies:
   - pip
   - pip:
     - epigraphhub
+    - containers-sugar==1.4.3
+    - makim==1.6.4


### PR DESCRIPTION
Adding extra deps to the project. Makim and containers-sugar are tools designed to avoid creating boilerplates across repositories and to simplify the management of the Docker stack.
By @Anavelyz and @YurelyCamacho 
@xmnlab 