### PR TITLE
fix(sinan): separate FTP nlst to a separate control DAG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,13 @@ containers-start-services: prepare-host
 .PHONY:containers-stop
 containers-stop:
 	set -ex
-	$(CONTAINER_APP) stop ${SERVICES}
+       $(CONTAINER_APP) stop ${ARGS} ${SERVICES}
+
+.PHONY:containers-rm
+containers-rm:
+       set -ex
+       $(CONTAINER_APP) rm ${ARGS} ${SERVICES}
+
 
 .PHONY:containers-restart
 containers-restart: containers-stop containers-start

--- a/containers/airflow/dags/brasil/sinan.py
+++ b/containers/airflow/dags/brasil/sinan.py
@@ -402,16 +402,11 @@ def task_flow_for(disease: str):
 # Here its where the DAGs are created, an specific case can be specified
 from airflow.models.dag import DAG
 from epigraphhub.data.brasil.sinan import DISEASES
-from airflow.utils.dag_parsing_context import get_parsing_context
 
 from random import randint
 
-current_dag_id = get_parsing_context().dag_id
-
 for disease in DISEASES:
     dag_id = 'SINAN_' + DISEASES[disease]
-    if current_dag_id is not None and current_dag_id != dag_id:
-        continue  # skip generation of non-selected DAG
 
     with DAG(
         dag_id=dag_id,

--- a/containers/airflow/dags/brasil/sinan.py
+++ b/containers/airflow/dags/brasil/sinan.py
@@ -77,17 +77,16 @@ def task_flow_for(disease: str):
     from itertools import chain
     from epigraphhub.connection import get_engine
     from airflow.exceptions import AirflowSkipException
-    from epigraphhub.data.brasil.sinan import FTP_SINAN, normalize_str
+    from epigraphhub.data.brasil.sinan import normalize_str
 
     schema = 'brasil'
     tablename = 'sinan_' + normalize_str(disease) + '_m'
     engine = get_engine(credential_name=env.db.default_credential)
 
-    prelim_years = list(map(int, FTP_SINAN(disease).get_years('prelim')))
-    finals_years = list(map(int, FTP_SINAN(disease).get_years('finais')))
-
+    # Extracts year from parquet file
     get_year = lambda file: int(str(file).split('.parquet')[0][-2:])
     
+    # Uploads DataFrame into EGH db
     upload_df = lambda df: df.to_sql(
         name=tablename, 
         con=engine.connect(), 
@@ -96,52 +95,43 @@ def task_flow_for(disease: str):
         index=False
     )
 
-    @task(task_id='start')
-    def start_task():
-        with engine.connect() as conn:
-            conn.execute(
-                f'CREATE TABLE IF NOT EXISTS {schema}.sinan_update_ctl ('
-                ' disease TEXT NOT NULL,'
-                ' year INT NOT NULL,'
-                ' prelim BOOL NOT NULL,'
-                ' last_insert DATE'
-                ')'
-            )
+    # Does nothing
+    start = EmptyOperator(
+        task_id='start',
+    )
 
     @task(task_id='get_updates')
     def dbcs_to_fetch() -> dict:
-        all_years = prelim_years + finals_years
-
-        db_years = []
+        # Get years that were not inserted yet
         with engine.connect() as conn:
-            try:
-                cur = conn.execute(
-                    f'SELECT year FROM {schema}.sinan_update_ctl'
-                    f" WHERE disease = '{disease}'"
-                )
-                years = cur.all()
-            except Exception as e:
-                if "UndefinedColumn" or "NoSuchTableError" in str(e):
-                    years = []
-            db_years.extend(list(chain(*years)))
-        # Compare years found in ctl table with FTP server
-        not_inserted = [y for y in all_years if y not in db_years]
+            cur = conn.execute(
+                f'SELECT year FROM {schema}.sinan_update_ctl'
+                f" WHERE disease = '{disease}' AND last_insert IS NULL"
+            )
+            years_to_insert = cur.all()
+        not_inserted = list(chain(*years_to_insert))
 
-        db_prelimns = []
-        with engine.connect() as conn:
-            try:
-                cur = conn.execute(
-                    f'SELECT year FROM {schema}.sinan_update_ctl'
-                    f" WHERE disease = '{disease}' AND prelim IS True"
-                )
-                years = cur.all()
-            except psycopg2.errors.lookup("42703"): #this is the UndefinedColumn code
-                years = []
-            db_prelimns.extend(list(chain(*years)))
-        # Get years that are not prelim anymore
-        prelim_to_final = [y for y in finals_years if y in db_prelimns]
         # Get prelims
-        prelim_to_update = [y for y in prelim_years if y in db_prelimns]
+        with engine.connect() as conn:
+            cur = conn.execute(
+                f'SELECT year FROM {schema}.sinan_update_ctl WHERE'
+                f" disease = '{disease}' AND"
+                f' prelim IS True AND'
+                f' last_insert IS NOT NULL'
+            )
+            prelim_years = cur.all()
+        prelim_to_update = list(chain(*prelim_years))
+
+        # Get years that are not prelim anymore
+        with engine.connect() as conn:
+            cur = conn.execute(
+                f'SELECT year FROM {schema}.sinan_update_ctl WHERE'
+                f" disease = '{disease}' AND"
+                f' prelim IS False AND'
+                f' to_final IS True'
+            )
+            prelim_to_final_years = cur.all()
+        prelim_to_final = list(chain(*prelim_to_final_years))
 
         return dict(
             to_insert=not_inserted,
@@ -156,6 +146,7 @@ def task_flow_for(disease: str):
         ti = kwargs['ti']
         years = ti.xcom_pull(task_ids='get_updates')
 
+        # Downloads dbc files into parquets to 
         extract_pqs = (
             lambda stage: extract.download(
                 disease=disease, years=years[stage]
@@ -174,17 +165,19 @@ def task_flow_for(disease: str):
 
         ti = kwargs['ti']
         parquets = ti.xcom_pull(task_ids='extract')['pqs_to_insert']
+        prelim_years = ti.xcom_pull(task_ids='get_updates')['to_update']
         inserted_rows = dict()
 
         if not parquets:
             logger.info('There is no new DBCs to insert on DB')
             raise AirflowSkipException()
 
+
         finals, prelims = ([], [])
         for parquet in parquets:
             (
                 finals.append(parquet)
-                if get_year(parquet) in finals_years
+                if get_year(parquet) not in prelim_years
                 else prelims.append(parquet)
             )
 
@@ -200,7 +193,7 @@ def task_flow_for(disease: str):
                 df = parquets_to_dataframe(str(parquet))
 
                 if df.empty:
-                    logger('DataFrame is empty')
+                    logger.error('DataFrame is empty')
                     continue
 
                 df['year'] = year
@@ -243,9 +236,9 @@ def task_flow_for(disease: str):
                     
                 with engine.connect() as conn:
                     conn.execute(
-                        f'INSERT INTO {schema}.sinan_update_ctl('
-                        'disease, year, prelim, last_insert) VALUES ('
-                        f"'{disease}', {year}, {prelim}, '{ti.execution_date}')"
+                        f'UPDATE {schema}.sinan_update_ctl SET'
+                        f" last_insert = '{ti.execution_date}' WHERE"
+                        f" disease = '{disease}' AND year = {year}"
                     )
                     cur = conn.execute(
                         f'SELECT COUNT(*) FROM {schema}.{tablename}'
@@ -386,7 +379,6 @@ def task_flow_for(disease: str):
     )
 
     # Defining the tasks
-    ini = start_task()
     dbcs = dbcs_to_fetch()
     E = extract_parquets()
     upload_new = upload_not_inserted()
@@ -395,25 +387,30 @@ def task_flow_for(disease: str):
     clean = remove_parquets()
 
     # Task flow
-    ini >> dbcs >> E >> upload_new >> to_final >> prelims >> clean >> end
+    start >> dbcs >> E >> upload_new >> to_final >> prelims >> clean >> end
 
 
 # DAGs
 # Here its where the DAGs are created, an specific case can be specified
 from airflow.models.dag import DAG
 from epigraphhub.data.brasil.sinan import DISEASES
+from airflow.utils.dag_parsing_context import get_parsing_context
 
 from random import randint
 
+current_dag_id = get_parsing_context().dag_id
+
 for disease in DISEASES:
     dag_id = 'SINAN_' + DISEASES[disease]
+    if current_dag_id is not None and current_dag_id != dag_id:
+        continue  # skip generation of non-selected DAG
 
     with DAG(
         dag_id=dag_id,
         default_args=DEFAULT_ARGS,
         tags=['SINAN', 'Brasil', disease],
         start_date=pendulum.datetime(
-            2022, 2, randint(1,28)
+            2022, 2, randint(2,28)
         ),
         catchup=False,
         schedule='@monthly',

--- a/containers/airflow/dags/brasil/sinan.py
+++ b/containers/airflow/dags/brasil/sinan.py
@@ -294,7 +294,7 @@ def task_flow_for(disease: str):
             with engine.connect() as conn:
                 conn.execute(
                     f'UPDATE {schema}.sinan_update_ctl'
-                    f" SET prelim = False, last_insert = '{ti.execution_date}'"
+                    f" SET 'to_final' = False, last_insert = '{ti.execution_date}'"
                     f" WHERE disease = '{disease}' AND year = {year}"
                 )
 
@@ -414,6 +414,6 @@ for disease in DISEASES:
         ),
         catchup=False,
         schedule='@monthly',
-        dagrun_timeout=timedelta(minutes=10),
+        dagrun_timeout=None,
     ):
         task_flow_for(disease)

--- a/containers/airflow/dags/brasil/sinan_ctl.py
+++ b/containers/airflow/dags/brasil/sinan_ctl.py
@@ -1,0 +1,113 @@
+import pendulum
+import logging as logger
+
+from datetime import timedelta
+
+from airflow import DAG
+from airflow.decorators import task
+from epigraphhub.data.brasil.sinan import FTP_SINAN
+
+from epigraphhub.settings import env
+from epigraphhub.connection import get_engine
+from epigraphhub.data.brasil.sinan import (
+    DISEASES,
+)
+
+DEFAULT_ARGS = {
+    'owner': 'epigraphhub',
+    'depends_on_past': False,
+    'email': ['epigraphhub@thegraphnetwork.org'],
+    'email_on_failure': True,
+    'email_on_retry': False,
+    'retries': 2,
+    'retry_delay': timedelta(minutes=2),
+}
+
+engine = get_engine(credential_name=env.db.default_credential)
+
+with DAG(
+    dag_id='SINAN_UPDATE_CTL',
+    default_args=DEFAULT_ARGS,
+    tags=['SINAN', 'CTL'],
+    start_date=pendulum.datetime(2023, 4, 1, 12, 30),
+    catchup=False,
+    schedule='@daily',
+    description='A DAG to update the SINAN control table in EGH db',
+):
+
+    schema = 'brasil'
+    tablename ='sinan_update_ctl'
+
+    @task(task_id='start')
+    def start_task():
+        with engine.connect() as conn:
+            conn.execute(
+                f'CREATE TABLE IF NOT EXISTS {schema}.{tablename} ('
+                ' disease TEXT NOT NULL,'
+                ' year INT NOT NULL,'
+                ' path TEXT NOT NULL,'
+                ' prelim BOOL NOT NULL,'
+                ' to_final BOOL NOT NULL DEFAULT False,'
+                ' last_insert DATE'
+                ')'
+            )
+
+    @task(task_id='update_ctl_table')
+    def update_table():
+        for disease in DISEASES.keys():
+            dis = FTP_SINAN(disease)
+
+            prelim_years = list(map(int, dis.get_years('prelim')))
+            finals_years = list(map(int, dis.get_years('finais')))
+            prelim_paths = dis.get_ftp_paths(prelim_years)
+            finals_paths = dis.get_ftp_paths(finals_years)
+
+            for year, path in zip(prelim_years, prelim_paths):
+                if not year: continue
+                with engine.connect() as conn:
+                    cur = conn.execute(
+                        f'SELECT prelim FROM {schema}.{tablename}'
+                        f" WHERE disease = '{disease}' AND year = {year}"
+                    )
+                    prelim = cur.fetchone()
+                
+                if prelim is None:
+                    with engine.connect() as conn:
+                        conn.execute(
+                            f'INSERT INTO {schema}.{tablename} ('
+                            f'disease, year, path, prelim) VALUES ('
+                            f"'{disease}', {year}, '{path}', True)"
+                            )
+                        logger.debug(f'Insert {disease} {year} {path}')
+
+            for year, path in zip(finals_years, finals_paths):
+                if not year: continue
+                with engine.connect() as conn:
+                    cur = conn.execute(
+                        f'SELECT prelim FROM {schema}.{tablename}'
+                        f" WHERE disease = '{disease}' AND year = {year}"
+                    )
+                    prelim = cur.fetchone()
+                
+                if prelim is None:
+                    with engine.connect() as conn:
+                        conn.execute(
+                            f'INSERT INTO {schema}.{tablename} ('
+                            f'disease, year, path, prelim) VALUES ('
+                            f"'{disease}', {year}, '{path}', True)"
+                        )
+                        logger.debug(f'Insert {disease} {year} {path}')
+                
+                elif prelim[0] is False:
+                    with engine.connect() as conn:
+                        conn.execute(
+                            f'UPDATE {schema}.{tablename} SET'
+                            f" prelim = False, to_final = True, path = '{path}'"
+                            f" WHERE disease = '{disease}' AND year = {year}"
+                        )
+                        logger.debug(f'Update to final {disease} {year} {path}')
+
+    start = start_task()
+    update = update_table()
+
+    start >> update

--- a/containers/airflow/dags/brasil/sinan_drop_table.py
+++ b/containers/airflow/dags/brasil/sinan_drop_table.py
@@ -36,21 +36,20 @@ with DAG(
     schedule=None, #Only manually triggered 
     description='A DAG to delete a SINAN table in EGH db',
 ):
-    def drop_tables(diseases: list):
-        for disease in diseases:
-            dis = normalize_str(disease)
-            tablename = 'sinan_' + dis + '_m'
-            with engine.connect() as conn:
-                conn.execute(
-                    f'DROP TABLE brasil.{tablename}'
-                )
-                logger.warn(f'Dropped table {tablename} on schema brasil')
+    def drop_tables(disease: str):
+        dis = normalize_str(disease)
+        tablename = 'sinan_' + dis + '_m'
+        with engine.connect() as conn:
+            conn.execute(
+                f'DROP TABLE brasil.{tablename}'
+            )
+            logger.warn(f'Dropped table {tablename} on schema brasil')
 
     delete_tables_task = PythonOperator(
         task_id='drop_table',
         python_callable=drop_tables,
-        op_kwargs={'diseases': '{{ params.diseases }}'},
-        params={'diseases': 'diseases'},
+        op_kwargs={'disease': '{{ params.disease }}'},
+        params={'disease': 'disease'},
     )
 
     delete_tables_task

--- a/containers/airflow/dags/brasil/sinan_drop_table.py
+++ b/containers/airflow/dags/brasil/sinan_drop_table.py
@@ -2,16 +2,13 @@ import pendulum
 import logging as logger
 
 from datetime import timedelta
-from epigraphhub.data.brasil.sinan import normalize_str
 
 from airflow import DAG
-from airflow.decorators import dag
 from airflow.operators.python import PythonOperator
 
 from epigraphhub.settings import env
 from epigraphhub.connection import get_engine
 from epigraphhub.data.brasil.sinan import (
-    DISEASES,
     normalize_str,
 )
 


### PR DESCRIPTION
Connecting and disconnecting to DataSUS FTP server was causing the SINAN DAGs to choke and therefore, automatically being dropped from DagBag. I've had to split part of the DAG which used ftplib.FTP.nslt() to its own DAG, now called SINAN_UPDATE_CTL and will run daily updating the `brasil.sinan_update_ctl` table.